### PR TITLE
feat: add disabled class for modal nav btns

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,14 +455,13 @@ https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contr
 <!-- ❓ Add important code snippets somewhere? -->
 
 > [!NOTE]
-> 15 To-Do items left - 5 High-priority + 2 important Non-critical (1 & 2)
+> 14 To-Do items left - 5 High-priority + 2 important Non-critical (1 & 2)
 
 ### High-priority
 
 1. **BOARD**: Start a slideshow of just the images, and/or the images + text - issue [#44](https://github.com/Kernix13/vision-grid-express/issues/44)
 2. **INDEX**: Implement error messsage/popup for searches of "bad characters" - issue [#46](https://github.com/Kernix13/vision-grid-express/issues/46)
-3. Add a `.disabled` class to the prev modal button when index = 0, and to next when index = arr.length - 1, set cursor to none & reduce opacity. Do I also need to add `removeEventListener`?
-4. **README**: Finish Use of AI
+3. **README**: Finish Use of AI
 
 ### Non-critical
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -562,6 +562,22 @@ input[type="search"]:focus {
 	background-color: var(--accent-3);
 }
 
+.modal .prev:disabled, 
+.modal .next:disabled {
+	color: #777;
+	background-color: #aaa;
+	cursor: not-allowed;
+}
+
+.modal .prev:disabled:hover,
+.modal .next:disabled:hover,
+.modal .prev:disabled:active,
+.modal .next:disabled:active {
+	color: #777;
+	background-color: #aaa;
+	border: 1px solid transparent;
+}
+
 .close-btn {
 	background-color: var(--primary-muted-2);
 	color: var(--text);

--- a/public/js/ui/modal.js
+++ b/public/js/ui/modal.js
@@ -57,17 +57,24 @@ function modalNav(btnsContainer, id, innerModal) {
 		btn.className = `nav ${item.name}`;
 		btn.textContent = item.symbol;
 
+		// saved-images for board page, fetched-search-results for index
+		if (page === '/board.html') {
+			images = getLocalStorage('saved-images');
+		} else {
+			images = getLocalStorage('fetched-search-results');
+		}
+		
+		const currentIndex = images.findIndex((img) => img.id === id);
+		
+		if (currentIndex === 0 && btn.classList.contains('prev')) {
+			btn.disabled = true;
+		}
+		if (currentIndex === images.length - 1 && btn.classList.contains('next')) {
+			btn.disabled = true;
+		}
+
 		btn.addEventListener('click', () => {
-			// saved-images for board page, fetched-search-results for index
-			if (page === '/board.html') {
-				images = getLocalStorage('saved-images');
-			} else {
-				images = getLocalStorage('fetched-search-results');
-			}
-
-			const currentIndex = images.findIndex((img) => img.id === id);
 			const nextIndex = currentIndex + item.direction;
-
 			if (nextIndex < 0 || nextIndex >= images.length) return;
 
 			let domImage;


### PR DESCRIPTION
## Description

I added the disabled attribute if the image in the modal is the first (`prev` btn) or last (`next` btn) item in `localStorage`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

Closes #59 
