### PR TITLE
refactor: setModalContent 2nd param and all function calls to match

### DIFF
--- a/public/js/board.js
+++ b/public/js/board.js
@@ -53,7 +53,7 @@ playSlider.addEventListener('click', () => {
 
 	// setModalContent is bad for this because of the second argument: img.src
 	// I need to pass that in I need to refactor the Fx and all functions calls
-	setModalContent(innerModal, pageImages[0], imageTextEls[0].id);
+	setModalContent(innerModal, pageImages[0].src, imageTextEls[0].id);
 
 	console.log(savedImages[0].imageRegular === pageImages[0].src)
 	console.log(savedImages[0].id === imageTextEls[0].id)
@@ -113,7 +113,7 @@ imgTextContainer.addEventListener('click', (e) => {
 
 	modalBg.classList.add('show-modal');
 	modalBg.hidden = false;
-	setModalContent(innerModal, regularImg, imageTextId);
+	setModalContent(innerModal, regularImg.src, imageTextId);
 });
 
 // 8. Adds/removes 'selected' class on click of any thumbnail

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -139,7 +139,7 @@ searchGrid.addEventListener('click', (e) => {
 	
 	modalBg.classList.add('show-modal');
 	modalBg.hidden = false;
-	setModalContent(innerModal, img, cardId);
+	setModalContent(innerModal, img.src, cardId);
 });
 
 // 8. Clear save searches and related buttons from the DOM

--- a/public/js/ui/modal.js
+++ b/public/js/ui/modal.js
@@ -4,11 +4,11 @@ const modalBg = document.getElementById('modal-bg');
 const innerModal = document.querySelector('.modal');
 
 // WHAT IMAGE SIZE AM I LOADING? It should be .regular, I think it is .small
-export function setModalContent(element, item, id) {
+export function setModalContent(element, imgSrc, id) {
 	element.textContent = '';
 
 	const image = document.createElement('img');
-	image.src = item.src;
+	image.src = imgSrc;
 	image.className = 'modal-image';
 
 	const btnsContainer = document.createElement('div');
@@ -82,9 +82,9 @@ function modalNav(btnsElement, imgId, modalElement) {
 			const domImageContainer = document.getElementById(nextImageObj.id);
 
 			if (page === '/board.html') {
-				domImage = domImageContainer.querySelector('.regular');
+				domImage = domImageContainer.querySelector('.regular').src;
 			} else {
-				domImage = domImageContainer.querySelector('.result-image');
+				domImage = domImageContainer.querySelector('.result-image').src;
 			}
 			setModalContent(modalElement, domImage, nextImageObj.id);
 		});
@@ -134,7 +134,7 @@ function modalSaveRemove(btnsElement, imgId, modalElement) {
 				const domImage = domImageContainer.querySelector('.result-image');
 
 				// Recursive call of setModalContent because this Fx is called there
-				setModalContent(modalElement, domImage, nextImageObj.id);
+				setModalContent(modalElement, domImage.src, nextImageObj.id);
 			}
 
 			if (updatedImages.length === 1) {


### PR DESCRIPTION
## Description

The 2nd parameter for `setModalContent` was change to the image `src` value.

## Checklist

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Kernix13/vision-grid-express/issues) for the same update/change?
- [x] I have a descriptive title for my PR
- [x] I have read and followed the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have tested these changes locally on my machine.

## Type of Change

- [x] Refactor/Chore items (this includes basic clean up of files, or updates to packages)

Closes #65 
