### PR TITLE
start image slider code to use setModalContent with setInterval in a new function

### DIFF
--- a/public/js/handlers/boardEvents.js
+++ b/public/js/handlers/boardEvents.js
@@ -1,6 +1,6 @@
 import { toggleDisplay } from '../ui/classUtils.js';
 import { setModalContent } from '../ui/modal.js';
-import { addSavedImagesToDom } from '../ui/savedImages.js';
+import { addSavedImagesToDom, playImageSlider } from '../ui/savedImages.js';
 import {
 	addThumbnailsToDom,
 	moveImage,
@@ -121,16 +121,10 @@ export function handleThumbnailBtns(event) {
  */
 export function handleSliderPlayBtn() {
 	innerModal.classList.add('play');
-	const savedImages = getLocalStorage('saved-images');
-
-	// I need to get the first get first DOM image and load it for now
-	const pageImages = document.querySelectorAll('img.regular');
-	const imageTextEls = document.querySelectorAll('.image-text');
 	modalBg.classList.add('show-modal');
 	modalBg.hidden = false;
 
-	setModalContent(innerModal, pageImages[0].src, imageTextEls[0].id);
-
+	playImageSlider();
 	toggleDisplay(settingsForm, settingsBtn, 'Settings');
 }
 

--- a/public/js/ui/savedImages.js
+++ b/public/js/ui/savedImages.js
@@ -1,4 +1,7 @@
 import { getLocalStorage } from '../utils/localStorage.js';
+import { setModalContent } from './modal.js';
+
+const innerModal = document.querySelector('.modal');
 
 export function addSavedImagesToDom() {
 	const savedImages = getLocalStorage('saved-images');
@@ -35,4 +38,21 @@ export function addSavedImagesToDom() {
 		imageText.append(p);
 		imgTextContainer.append(imageText);
 	});
+}
+
+export function playImageSlider() {
+  const images = getLocalStorage('saved-images');
+  let idx = 0;
+	// Eventually 6000 (defaults) & then grab the user's value
+  let timing = 3000;
+
+	// I needed the first image out of setInterval because...
+  setModalContent(innerModal, images[idx].imageRegular, images[idx].id);
+
+  setInterval(() => {
+    idx++;
+    if (idx >= images.length) idx = 0;
+
+    setModalContent(innerModal, images[idx].imageRegular, images[idx].id);
+  }, timing);
 }


### PR DESCRIPTION
## Description

I was able to use the code from module 3, week 3, lesson 12 for express card part 3:

```js
// Code from the express quote card lesson:
function loopThroughQuotes() {
  let quoteIndex = 0;
  setInterval(() => {
    if (quoteIndex < quotes.length) {
      elements.quote.textContent = quotes[quoteIndex].quote;
      elements.author.textContent = quotes[quoteIndex].author;
      quoteIndex++;
    } else {
      quoteIndex = 0;
    }
  }, 3000);
}

// Modified to this:
export function playImageSlider() {
  const images = getLocalStorage('saved-images');
  let idx = 0;
	// Eventually 6000 (defaults) & then grab the user's value
  let timing = 3000;

	// I needed the first image out of setInterval because...
  setModalContent(innerModal, images[idx].imageRegular, images[idx].id);

  setInterval(() => {
    idx++;
    if (idx >= images.length) idx = 0;

    setModalContent(innerModal, images[idx].imageRegular, images[idx].id);
  }, timing);
}
```

I had to import `setModalContent` and div.modal from the DOM into `savedImages.js`. Then I exported into `boardEvents.js`. It worked but with some issues: I need to use `clearInterval` but that will have to be called in my 3 close modal listeners which are in `board.js`. It just got complicated...

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have tested these changes locally on my machine.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

